### PR TITLE
[NT] Fixed validation exception handling.

### DIFF
--- a/.idea/jsLibraryMappings.xml
+++ b/.idea/jsLibraryMappings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="JavaScriptLibraryMappings">
+    <includedPredefinedLibrary name="dncr/frontend/node_modules" />
+  </component>
+</project>

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -52,17 +52,13 @@ class Handler extends ExceptionHandler
   {
     if($request->isXmlHttpRequest() || $request->isJson())
     {
-      if($e instanceof HttpResponseException)
+      if($e instanceof HttpResponseException || $e instanceof ValidationException)
       {
         return $e->getResponse();
       }
       elseif($e instanceof ModelNotFoundException)
       {
         return response()->json($e->getMessage(), 404);
-      }
-      elseif($e instanceof ValidationException && $e->getResponse())
-      {
-        return response()->json($e->getResponse(), 400);
       }
       elseif($e instanceof NotFoundHttpException)
       {


### PR DESCRIPTION
After long struggle I've finally figured out why validation stopped working.
![image](https://cloud.githubusercontent.com/assets/10455138/19540698/8d678dac-9661-11e6-8db3-d73c884253a9.png)
(https://laravel.com/docs/5.3/upgrade)

And I guess somebody mistakenly removed `jsLibraryMappings.xml`, so there it is back.
